### PR TITLE
fix TX ID case matching

### DIFF
--- a/orfannotate/gtf_annotation.py
+++ b/orfannotate/gtf_annotation.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from collections import defaultdict, OrderedDict
 
-from orfannotate.utils import _build_tx_lookup, _extract_tid_from_attrs, TRANSCRIPT_LIKE_FEATURES
+from orfannotate.utils import _build_tx_lookup, _extract_tid_from_attrs, TRANSCRIPT_LIKE_FEATURES, _normalize_tid
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,13 @@ def build_cds_features(gtf_db, best_orfs):
     cds_features = []
 
     for tid, orf in best_orfs.items():
-        tx = tx_lookup.get(tid) or tx_lookup.get(tid.split('.')[0])
+        tid_base = tid.split(".")[0]
+        tx = (
+            tx_lookup.get(tid)
+            or tx_lookup.get(tid_base)
+            or tx_lookup.get(_normalize_tid(tid))
+            or tx_lookup.get(_normalize_tid(tid_base))
+        )
         
         if tx is None:
             logger.warning(f"[CDS] No transcript found for {tid}")
@@ -58,7 +64,7 @@ def build_cds_features(gtf_db, best_orfs):
 
             common_attrs = {
                 "gene_id":      tx.attributes.get("gene_id", [""])[0],
-                "transcript_id": tid,
+                "transcript_id": tx.attributes.get("transcript_id", [tid])[0],
                 "gene_name":    tx.attributes.get("gene_name", [""])[0],
                 "ref_gene_id":  tx.attributes.get("ref_gene_id", [""])[0],
             }

--- a/orfannotate/orf_filter.py
+++ b/orfannotate/orf_filter.py
@@ -3,13 +3,19 @@ import logging
 import re
 from collections import defaultdict
 
+from orfannotate.utils import _normalize_tid
+
 logger = logging.getLogger(__name__)
 
 def get_best_orfs_by_cpat(cpat_best_path, all_orfs_df=None, debug_output_path=None):
     df = pd.read_csv(cpat_best_path, sep='\t')
     
     # Strip ORF suffix to group by transcript
-    df["base_id"] = df["ID"].str.replace(r'_ORF_\d+$', '', regex=True)
+    df["base_id"] = (
+        df["ID"]
+        .str.replace(r'_ORF_\d+$', '', regex=True)
+        .map(_normalize_tid)
+    )
 
     # Keep only highest-scoring ORF per base transcript ID
     best_per_transcript = df.sort_values('Coding_prob', ascending=False).groupby('base_id').first()

--- a/orfannotate/orf_prediction.py
+++ b/orfannotate/orf_prediction.py
@@ -4,6 +4,7 @@ import logging
 import pandas as pd
 
 from orfannotate.orf_filter import get_best_orfs_by_cpat
+from orfannotate.utils import _normalize_tid
 
 logger = logging.getLogger(__name__)
 
@@ -64,17 +65,19 @@ def predict_uorf(output_dir, hexamer_path, logit_model_path, coding_cutoff, top_
     best_uorf = get_best_orfs_by_cpat(uorf_cpat_results, debug_output_path=uorf_debug_output)
 
     # Lookup dict for quick canonical tx_id and ORF_start access
+    canonical_orf_cpat_df["norm_seq_ID"] = canonical_orf_cpat_df["seq_ID"].map(_normalize_tid)
+    
     canon_orf_start = (
         canonical_orf_cpat_df
-        .set_index("seq_ID")["ORF_start"]
+        .set_index("norm_seq_ID")["ORF_start"]
         .to_dict()
     )
-
+    
     # Filter uORFs so that only TRUE uORFs remain (end < canonical ORF start)
     selected_uorfs = {}
     for tx, uorf in best_uorf.items():
 
-        orf_start = canon_orf_start.get(tx)
+        orf_start = canon_orf_start.get(_normalize_tid(tx))
 
         if orf_start is None:
             # no canonical ORF found > skip
@@ -92,8 +95,12 @@ def predict_uorf(output_dir, hexamer_path, logit_model_path, coding_cutoff, top_
     orf_summary = pd.read_csv(summary_tsv_path, sep='\t')    
 
     # Update the final 'summary.tsv': add the new two uORF columns
-    orf_summary["has_uORF"] = orf_summary["transcript_id"].map(lambda x: selected_uorfs.get(x) is not None)
-    orf_summary["coding_prob_best_uORF"] = orf_summary["transcript_id"].map(selected_uorfs)
+    orf_summary["has_uORF"] = orf_summary["transcript_id"].map(
+        lambda x: selected_uorfs.get(_normalize_tid(x)) is not None
+    )
+    orf_summary["coding_prob_best_uORF"] = orf_summary["transcript_id"].map(
+        lambda x: selected_uorfs.get(_normalize_tid(x))
+    )
    
     # Save results
     orf_summary.to_csv(summary_tsv_path,

--- a/orfannotate/summarise.py
+++ b/orfannotate/summarise.py
@@ -16,7 +16,7 @@ from rich.progress import Progress
 # Internal modules
 from orfannotate.nmd import predict_nmd
 from orfannotate.kozak import score_kozak
-from orfannotate.utils import _load_transcript_sequences, _map_junctions_to_tx, _create_db
+from orfannotate.utils import _load_transcript_sequences, _map_junctions_to_tx, _create_db, _normalize_tid
 
 LOGGER = logging.getLogger(__name__)
 logging.basicConfig(format="%(levelname)s:%(name)s:%(message)s", level=logging.INFO)
@@ -45,8 +45,12 @@ def generate_summary(best_orfs, transcript_fa, gtf_db_or_path, output_path, outp
     utr5_records = []
     utr3_records = []
 
-    all_tx_ids = {t.id for t in db.features_of_type("transcript")}
-    all_tx_ids &= set(transcript_seqs.keys())
+    fasta_ids_norm = {_normalize_tid(tid) for tid in transcript_seqs.keys()}
+    
+    all_tx_ids = {
+        tid for tid in (t.id for t in db.features_of_type("transcript"))
+        if _normalize_tid(tid) in fasta_ids_norm
+    }
     
     children = db.children
     
@@ -54,8 +58,18 @@ def generate_summary(best_orfs, transcript_fa, gtf_db_or_path, output_path, outp
 
     for tid in sorted(all_tx_ids): 
         
-        has_orf = tid in best_orfs
-        orf_data = best_orfs.get(tid, None)
+        tid_base = tid.split(".")[0]
+        tid_norm = _normalize_tid(tid)
+        tid_base_norm = _normalize_tid(tid_base)
+        
+        orf_data = (
+            best_orfs.get(tid)
+            or best_orfs.get(tid_base)
+            or best_orfs.get(tid_norm)
+            or best_orfs.get(tid_base_norm)
+        )
+        
+        has_orf = orf_data is not None
         
         try:
             tx = db[tid]
@@ -94,7 +108,18 @@ def generate_summary(best_orfs, transcript_fa, gtf_db_or_path, output_path, outp
             else "noncoding"
         )
         
-        full_seq = str(transcript_seqs[tid].seq)
+        seq_record = (
+            transcript_seqs.get(tid)
+            or transcript_seqs.get(tid_base)
+            or transcript_seqs.get(tid_norm)
+            or transcript_seqs.get(tid_base_norm)
+        )
+        
+        if seq_record is None:
+            continue
+        
+        full_seq = str(seq_record.seq)
+        
         seq_len = len(full_seq)
 
         if coding_class == "coding":

--- a/orfannotate/utils.py
+++ b/orfannotate/utils.py
@@ -30,6 +30,13 @@ TRANSCRIPT_LIKE_FEATURES = {
     "ncRNA",
 }
 
+# CPAT uppercases IDs  but some GTFs have lowercase transcript_ids, so we normalise to uppercase for lookups.
+def _normalize_tid(tid):
+    if tid is None:
+        return None
+    return str(tid).upper()
+
+
 def _check_seqid_compatibility(db, genome, max_missing_examples: int = 20):
     """
     Check whether all seqids (contig/chromosome names) referenced in the annotation
@@ -405,13 +412,18 @@ class _ColoredTaskProgressColumn(TaskProgressColumn):
         base = super().render(task)
         return Text(str(base), style=self._style)
 
+
 def _build_tx_lookup(db):
     lut = {}
     for ftype in TRANSCRIPT_LIKE_FEATURES:
         for tx in db.features_of_type(ftype):
             tid_full = tx.attributes["transcript_id"][0]
+            tid_base = tid_full.split(".")[0]
+
             lut[tid_full] = tx
-            lut[tid_full.split(".")[0]] = tx
+            lut[tid_base] = tx
+            lut[_normalize_tid(tid_full)] = tx
+            lut[_normalize_tid(tid_base)] = tx
     return lut
 
 


### PR DESCRIPTION
Fixes transcript ID mismatch caused by CPAT uppercasing IDs.
Introduces case-insensitive matching across ORF parsing, annotation, and summary generation.
Resolves issue #3 where CDS were not reported for NNIC transcripts.